### PR TITLE
Replace zip library to fix npz support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "SwiftZip",
-        "repositoryURL": "https://github.com/qoncept/swift-zip.git",
+        "repositoryURL": "https://github.com/SwiftZip/SwiftZip.git",
         "state": {
           "branch": null,
-          "revision": "a2db547b32d1cfd3539df2688efc6e08b53f14d3",
-          "version": "0.0.4"
+          "revision": "97c2303d0fcc0bb6ae78a93ee10bdb91a1467c8f",
+          "version": "0.0.5"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/qoncept/swift-zip.git", from: "0.0.4")
+        .package(url: "https://github.com/SwiftZip/SwiftZip.git", from: "0.0.5"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftNpy/NpzLoader.swift
+++ b/Sources/SwiftNpy/NpzLoader.swift
@@ -9,11 +9,14 @@ extension Npz {
     }
     
     public init(data: Data) throws {
-        let dataDict = unzip(data: data)
+        let source = try ZipSource(data: data)
+        let archive = try ZipArchive(source: source)
         
         var dict = [String: Npy]()
-        for k in dataDict.keys {
-            dict[k] = try Npy(data: dataDict[k]!)
+        for entry in archive.entries() {
+            let entryName = try entry.getName()
+            let entryData = try entry.data()
+            dict[entryName] = try Npy(data: entryData)
         }
         
         self.init(dict: dict)

--- a/Sources/SwiftNpy/NpzSaver.swift
+++ b/Sources/SwiftNpy/NpzSaver.swift
@@ -4,16 +4,13 @@ import SwiftZip
 
 extension Npz {
     public func save(to url: URL) throws {
-        let data = self.format()
-        try data.write(to: url)
-    }
-    
-    public func format() -> Data {
-        var entries = [String: Data]()
-        for (k, v) in dict {
-            entries[k] = v.format()
+        let archive = try ZipMutableArchive(url: url, flags: [.create, .truncate])
+        
+        for (name, npy) in dict {
+            let source = try ZipSource(data: npy.format())
+            try archive.addFile(name: name, source: source)
         }
-        return createZip(entries: entries)
+        
+        try archive.close()
     }
-
 }

--- a/Tests/SwiftNpyTests/NpzSaverTests.swift
+++ b/Tests/SwiftNpyTests/NpzSaverTests.swift
@@ -9,8 +9,11 @@ class NpzSaverTests: XCTestCase {
         let a1Elements: [Int] = a1.elements()
         let b1: Npy = npz1["b"]!
         let b1Elements: [Int] = b1.elements()
+
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory() + "test.npz")
+        try! npz1.save(to: tempURL)
         
-        let data = npz1.format()
+        let data = try! Data(contentsOf: tempURL)
         
         let npz2: Npz = try! Npz(data: data)
         

--- a/readme.md
+++ b/readme.md
@@ -10,12 +10,12 @@ try save(npy: npy, to: url)
 ```
 
 ```swift
-let npz = try Npy(contentsOf: npzUrl)
+let npz = try Npz(contentsOf: npzUrl)
 let npy = npz["name-of-array"]
-try save(npz: npz, to: url)
+try npz.save(to: url)
 ```
 
-## Suppoted format
+## Suppoted formats
 `npy`, `npz` files.
 
 ### Bool


### PR DESCRIPTION
Hey guys,

First, thanks for an awesome package, it's truly a lifesaver!

Current `swift-zip` library fails to decompress most of `npz` files. For me it works just for arrays with `int64`s, fails for `float` data, for some unknown reasons.
So, I have replaced the lib with [SwiftZip](https://github.com/SwiftZip/SwiftZip) and rewrote `NpzLoader` and `NpzSaver`.

Also updated README to reflect changes.