### PR TITLE
Fix/workaround for test failure on iOS 18

### DIFF
--- a/Sources/SwiftNpy/NpyLoader.swift
+++ b/Sources/SwiftNpy/NpyLoader.swift
@@ -10,7 +10,7 @@ extension Npy {
     }
     
     public init(data: Data) throws {
-        guard let magic = String(data: data.subdata(in: 0..<6), encoding: .ascii) else {
+        guard let magic = String(data: data.subdata(in: 0..<6), encoding: .isoLatin1) else {
             throw NpyLoaderError.ParseFailed(message: "Can't parse prefix")
         }
         guard magic == MAGIC_PREFIX else {


### PR DESCRIPTION
iOS 18 breaks this library, due to a change in behaviour of `String(data:encoding:)` when the string encoding is `.ascii`.

Before iOS 18, the `.ascii` encoding allowed the `\u{93}` character in the npy header. In iOS 18, the `.ascii` encoding rejects this character, causing the String initializer to fail.

This PR changes the encoding to `.isoLatin1`, which allows the String to be initialized as it was before.

While this change works, a more robust approach might be a comparison that doesn't rely on String encodings and compares bytes directly.