### PR TITLE
Use Data for MAGIC_PREFIX

### DIFF
--- a/Sources/SwiftNpy/NpyHeader.swift
+++ b/Sources/SwiftNpy/NpyHeader.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-let MAGIC_PREFIX = "\u{93}NUMPY"
+let MAGIC_PREFIX = Data([0x93]) + "NUMPY".data(using: .ascii)!
 
 struct NpyHeader {
     let shape: [Int]

--- a/Sources/SwiftNpy/NpyLoader.swift
+++ b/Sources/SwiftNpy/NpyLoader.swift
@@ -10,9 +10,7 @@ extension Npy {
     }
     
     public init(data: Data) throws {
-        guard let magic = String(data: data.subdata(in: 0..<6), encoding: .ascii) else {
-            throw NpyLoaderError.ParseFailed(message: "Can't parse prefix")
-        }
+        let magic = data.subdata(in: 0..<6)
         guard magic == MAGIC_PREFIX else {
             throw NpyLoaderError.ParseFailed(message: "Invalid prefix: \(magic)")
         }

--- a/Sources/SwiftNpy/NpySaver.swift
+++ b/Sources/SwiftNpy/NpySaver.swift
@@ -10,11 +10,7 @@ extension Npy {
     public func format() -> Data {
         var data = Data()
         
-        let magic = MAGIC_PREFIX.unicodeScalars.map { c -> UInt8 in
-            return UInt8(c.value)
-        }
-        
-        data.append(contentsOf: magic)
+        data.append(contentsOf: MAGIC_PREFIX)
         
         let header = encodeHeader(self.header)
         


### PR DESCRIPTION
This PR resolves #3 by changing magic prefix handling.

Current implementation checks magic prefix as `String` and it's causing problem in the latest Swift.
Resolving it by checking magic prefix as `Data`.

I also changed `MAGIC_PREFIX` to simplify the code.